### PR TITLE
update regex to allow for urls with equal signs

### DIFF
--- a/rss2hook.go
+++ b/rss2hook.go
@@ -73,7 +73,7 @@ func loadConfig(filename string) {
 			//
 			// Otherwise find the feed + post-point
 			//
-			parser := regexp.MustCompile("^(.*)=([^=]+)")
+			parser := regexp.MustCompile("^(.+?)=([^=].+)")
 			match := parser.FindStringSubmatch(tmp)
 
 			//


### PR DESCRIPTION
I ran into an issue where if the destination url had equals signs in it, it would fails to parse. I used https://regexr.com to test it out. Here is the failed use case:

https://regexr.com/7qo18

And here is the working one:

https://regexr.com/7qo1b

I did do a quick build to test it out and it worked out for me. But please let me know if this is an okay change.

Thanks.